### PR TITLE
Removed anonymous from create organization route

### DIFF
--- a/backend/Watchdog.Core/Watchdog.Core.API/Controllers/OrganizationsController.cs
+++ b/backend/Watchdog.Core/Watchdog.Core.API/Controllers/OrganizationsController.cs
@@ -55,7 +55,6 @@ namespace Watchdog.Core.API.Controllers
             return Ok(organizations);
         }
         
-        [AllowAnonymous]
         [HttpPost]
         public async Task<ActionResult<OrganizationDto>> CreateOrganizationAsync(NewOrganizationDto organizationDto)
         {


### PR DESCRIPTION
I forgot that we create organization without token only when registering. Organization create on registration/full or partial